### PR TITLE
Add Keycloak login and registration pages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@react-keycloak/web": "^4.0.2",
-    "keycloak-js": "^24.0.0"
+    "keycloak-js": "^24.0.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import { ReactKeycloakProvider, useKeycloak } from '@react-keycloak/web';
 import Keycloak from 'keycloak-js';
 
@@ -13,13 +14,41 @@ const LoginPage = () => {
   if (keycloak.authenticated) {
     return <p>Welcome, {keycloak.tokenParsed.preferred_username}</p>;
   }
-  return <button onClick={() => keycloak.login()}>Login</button>;
+  return (
+    <div>
+      <h2>Login</h2>
+      <button onClick={() => keycloak.login()}>Login</button>
+      <p>
+        Don't have an account? <Link to="/register">Register</Link>
+      </p>
+    </div>
+  );
+};
+
+const RegisterPage = () => {
+  const { keycloak } = useKeycloak();
+  if (keycloak.authenticated) {
+    return <p>You are logged in as {keycloak.tokenParsed.preferred_username}</p>;
+  }
+  return (
+    <div>
+      <h2>Register</h2>
+      <button onClick={() => keycloak.register()}>Create Account</button>
+      <p>
+        Already have an account? <Link to="/">Login</Link>
+      </p>
+    </div>
+  );
 };
 
 const App = () => (
-  <ReactKeycloakProvider authClient={keycloak}
-    initOptions={{ onLoad: 'login-required' }}>
-    <LoginPage />
+  <ReactKeycloakProvider authClient={keycloak} initOptions={{ onLoad: 'check-sso' }}>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/*" element={<LoginPage />} />
+      </Routes>
+    </BrowserRouter>
   </ReactKeycloakProvider>
 );
 


### PR DESCRIPTION
## Summary
- add react-router-dom dependency
- create login and registration pages in the React frontend

## Testing
- `npm install` *(fails: No matching version for @react-keycloak/web@^4.0.2)*
- `npm run build` *(fails: webpack not found)*
- `mvn -q test` *(fails: mvn command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ee1f8af4832f99d90a3753342d5d