### PR TITLE
Update login page path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ docker compose up --build
 ```
 
 The front-end will be available at `http://localhost:3000` and Keycloak at `http://localhost:8080`.
+Open `http://localhost:3000/login` to access the login page or `http://localhost:3000/register` to register a new account.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link, Navigate } from 'react-router-dom';
 import { ReactKeycloakProvider, useKeycloak } from '@react-keycloak/web';
 import Keycloak from 'keycloak-js';
 
@@ -35,7 +35,7 @@ const RegisterPage = () => {
       <h2>Register</h2>
       <button onClick={() => keycloak.register()}>Create Account</button>
       <p>
-        Already have an account? <Link to="/">Login</Link>
+        Already have an account? <Link to="/login">Login</Link>
       </p>
     </div>
   );
@@ -45,8 +45,9 @@ const App = () => (
   <ReactKeycloakProvider authClient={keycloak} initOptions={{ onLoad: 'check-sso' }}>
     <BrowserRouter>
       <Routes>
+        <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
-        <Route path="/*" element={<LoginPage />} />
+        <Route path="/*" element={<Navigate to="/login" replace />} />
       </Routes>
     </BrowserRouter>
   </ReactKeycloakProvider>


### PR DESCRIPTION
## Summary
- serve login page at `/login` instead of root
- document new `/login` route in README

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846f47e5f64832f847c2e7bf763209d